### PR TITLE
Fix bullet terminology typo

### DIFF
--- a/warigari_surviver.html
+++ b/warigari_surviver.html
@@ -128,13 +128,13 @@
   let playerIframeDuration = 800;  // 피격 후 무적 시간 (ms)
   let playerHitFlashDuration = 200; // 피격 시 시각 효과 지속 시간 (ms)
   
-  // 이알 관련
-  let bulletSpeed = 460;           // 이알 속도 (px/s)
-  let bulletSize = 8;              // 이알 크기
-  let bulletCooldown = 420;        // 이알 발사 쿨다운 (ms)
-  let bulletDamage = 18;           // 이알 피해량
-  let bulletPenetration = false;   // 이알 관통 여부
-  let bulletKnockback = 0;         // 이알 넉백 거리 (px)
+  // 총알 관련
+  let bulletSpeed = 460;           // 총알 속도 (px/s)
+  let bulletSize = 8;              // 총알 크기
+  let bulletCooldown = 420;        // 총알 발사 쿨다운 (ms)
+  let bulletDamage = 18;           // 총알 피해량
+  let bulletPenetration = false;   // 총알 관통 여부
+  let bulletKnockback = 0;         // 총알 넉백 거리 (px)
   
   // 적 관련
   let enemyContactDamage = 10;     // 적 접촉 시 플레이어가 받는 피해
@@ -181,7 +181,7 @@
     {
       id: 'damage',
       title: '🔥 공격력 증가',
-      desc: '이알 피해량 +7',
+      desc: '총알 피해량 +7',
       apply: () => { bulletDamage += 7; }
     },
     {
@@ -214,13 +214,13 @@
     {
       id: 'knockback',
       title: '💥 넉백 공격',
-      desc: '이알이 적을 뒤로 밀어냄',
+      desc: '총알이 적을 뒤로 밀어냄',
       apply: () => { bulletKnockback += 40; }
     },
     {
       id: 'penetration',
       title: '🎯 관통 공격',
-      desc: '이알이 적을 관통함',
+      desc: '총알이 적을 관통함',
       apply: () => { bulletPenetration = true; }
     }
   ];
@@ -640,7 +640,7 @@
       // 우선 이동
       e.x = nextX;
 
-      // 이알과 충돌(피해 처리)
+      // 총알과 충돌(피해 처리)
       for (let j = bullets.length - 1; j >= 0; j--) {
         const b = bullets[j];
         if (aabb(e, b)) {
@@ -653,7 +653,7 @@
             e.x = clamp(e.x, -enemySize, WORLD.w);
           }
           
-          // 관통이 아니면 이알 제거
+          // 관통이 아니면 총알 제거
           if (!b.penetrating) {
             bullets.splice(j, 1);
           }


### PR DESCRIPTION
## Summary
- Rename Korean term '이알' to the correct '총알' throughout the game configuration and comments

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b67b0a9ed08332a73d224d455e5cfc