### PR TITLE
fix: maintain fixed aspect ratio

### DIFF
--- a/warigari_surviver.html
+++ b/warigari_surviver.html
@@ -17,8 +17,9 @@
 
     #wrap {
       display: flex;
-      flex-direction: column;
       height: 100%;
+      align-items: center;
+      justify-content: center;
     }
 
     header {
@@ -29,6 +30,7 @@
       display: flex;
       align-items: center;
       gap: 10px;
+      width: 100%;
     }
 
     header .pill {
@@ -39,7 +41,7 @@
     }
 
     #canvasWrap {
-      flex: 1;
+      flex: none;
       position: relative;
     }
 
@@ -523,10 +525,16 @@
       // 화면/맵
       function fitCanvas() {
         const wrap = document.getElementById('canvasWrap');
-        const w = wrap.clientWidth;
-        const h = wrap.clientHeight;
-        const targetH = Math.min(h, w * 9 / 16);
-        canvas.style.height = targetH + 'px';
+        const w = window.innerWidth;
+        const h = window.innerHeight;
+        let targetW = w;
+        let targetH = w * 9 / 16;
+        if (targetH > h) {
+          targetH = h;
+          targetW = h * 16 / 9;
+        }
+        wrap.style.width = targetW + 'px';
+        wrap.style.height = targetH + 'px';
       }
       window.addEventListener('resize', fitCanvas);
       fitCanvas();


### PR DESCRIPTION
## Summary
- ensure game start button initializes correctly by sizing canvas based on window dimensions
- center game container and keep 16:9 aspect ratio across browser sizes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b83e91f2e48332b526b153c4a145fb