### PR TITLE
Add spearhead to offense enemy weapon

### DIFF
--- a/warigari_surviver.html
+++ b/warigari_surviver.html
@@ -1780,8 +1780,29 @@
           if (e.type && e.type.id === 'offense') {
             ctx.fillStyle = '#cbd5e1';
             const extra = e.range - e.w;
+            const tipLen = Math.min(4, extra);
+            const shaftLen = extra - tipLen;
             const sx = e.vx >= 0 ? e.x + e.w : e.x - extra;
-            ctx.fillRect(sx, e.y + e.h * 0.5 - 1, extra, 2);
+            const sy = e.y + e.h * 0.5 - 1;
+            if (e.vx >= 0) {
+              ctx.fillRect(sx, sy, shaftLen, 2);
+            } else {
+              ctx.fillRect(sx + tipLen, sy, shaftLen, 2);
+            }
+            const tx = e.vx >= 0 ? sx + shaftLen : sx + tipLen;
+            const ty = e.y + e.h * 0.5;
+            ctx.beginPath();
+            if (e.vx >= 0) {
+              ctx.moveTo(tx, ty - 3);
+              ctx.lineTo(tx + tipLen, ty);
+              ctx.lineTo(tx, ty + 3);
+            } else {
+              ctx.moveTo(tx, ty - 3);
+              ctx.lineTo(tx - tipLen, ty);
+              ctx.lineTo(tx, ty + 3);
+            }
+            ctx.closePath();
+            ctx.fill();
           }
 
           ctx.fillStyle = '#0008';


### PR DESCRIPTION
## Summary
- Give offense-type enemies a spearhead by adding a triangular tip to their rod attack for a more spear-like look

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b957aa6d488332b4ca5678deb99cd7