### PR TITLE
feat: add boss attack pre-effect

### DIFF
--- a/warigari_surviver.html
+++ b/warigari_surviver.html
@@ -1135,6 +1135,24 @@
         b.returning = false;
       }
 
+      function bossPreEffectActive(b) {
+        if (!b.isBoss) return false;
+        if (b.attackState === "laser" && b.laserCount === 0 && b.attackCooldown <= 1000)
+          return true;
+        if (
+          b.attackState === "jump" &&
+          b.jumpCount === 0 &&
+          !b.jumping &&
+          b.attackCooldown <= 1000
+        )
+          return true;
+        if (b.attackState === "airLaser" && b.laserCount === 0 && b.attackCooldown <= 1000)
+          return true;
+        if (b.attackState === "bomb" && b.bombCount === 0 && b.attackCooldown <= 1000)
+          return true;
+        return false;
+      }
+
       function spawnBoss() {
         const size = enemySize * 3;
         let hpBase;
@@ -2366,6 +2384,22 @@
 
         // 적
         for (const e of enemies) {
+          if (bossPreEffectActive(e)) {
+            const progress = Math.min(
+              1,
+              Math.max(0, 1 - e.attackCooldown / 1000),
+            );
+            const radius = e.w * (1 + 0.5 * progress);
+            ctx.save();
+            ctx.strokeStyle = "#ff6b9d";
+            ctx.lineWidth = 4;
+            ctx.globalAlpha = 0.5 + 0.5 * progress;
+            ctx.beginPath();
+            ctx.arc(e.x + e.w / 2, e.y + e.h / 2, radius, 0, Math.PI * 2);
+            ctx.stroke();
+            ctx.restore();
+          }
+
           ctx.fillStyle = e.color;
           ctx.fillRect(e.x, e.y, e.w, e.h);
 


### PR DESCRIPTION
## Summary
- add helper to detect boss attack telegraph phase
- draw warning ring before bosses start patterns

## Testing
- `npm test` *(fails: enoent package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bda21db4e88332ab6bf683198cb71c