### PR TITLE
feat: telegraph boss lasers

### DIFF
--- a/warigari_surviver.html
+++ b/warigari_surviver.html
@@ -1235,20 +1235,26 @@
         b.returning = false;
       }
 
+      const BOSS_PRE_EFFECT_TIME = {
+        laser: 500,
+        timedLaser: 300,
+      };
+
       function bossPreEffectActive(b) {
         if (!b.isBoss) return false;
-        if (b.attackState === "laser" && b.laserCount === 0 && b.attackCooldown <= 1000)
-          return true;
+        const effectTime = BOSS_PRE_EFFECT_TIME[b.attackState] || 1000;
         if (
           b.attackState === "jump" &&
           b.jumpCount === 0 &&
           !b.jumping &&
-          b.attackCooldown <= 1000
+          b.attackCooldown <= effectTime
         )
           return true;
-        if (b.attackState === "airLaser" && b.laserCount === 0 && b.attackCooldown <= 1000)
+        if (b.attackState === "airLaser" && b.laserCount === 0 && b.attackCooldown <= effectTime)
           return true;
-        if (b.attackState === "timedLaser" && b.laserCount === 0 && b.attackCooldown <= 1000)
+        if (b.attackState === "laser" && b.laserCount < 5 && b.attackCooldown <= effectTime)
+          return true;
+        if (b.attackState === "timedLaser" && b.laserCount < 10 && b.attackCooldown <= effectTime)
           return true;
         return false;
       }
@@ -1378,7 +1384,7 @@
             if (b.laserCount < 5) {
               fireBossLaser(b);
               b.laserCount++;
-              b.attackCooldown = 700;
+              b.attackCooldown = 1000;
             } else if (!bossLasers.some((l) => l.owner === b)) {
               if (currentWave === 3) {
                 b.attackState = "jump";
@@ -2549,9 +2555,10 @@
         // 적
         for (const e of enemies) {
           if (bossPreEffectActive(e)) {
+            const effectTime = BOSS_PRE_EFFECT_TIME[e.attackState] || 1000;
             const progress = Math.min(
               1,
-              Math.max(0, 1 - e.attackCooldown / 1000),
+              Math.max(0, 1 - e.attackCooldown / effectTime),
             );
             const radius = e.w * (1 + 0.5 * progress);
             ctx.save();


### PR DESCRIPTION
## Summary
- extend delay between boss laser shots
- show telegraph effect before each laser and timed laser strike

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bf887ef8148332957befaf3e305b28