### PR TITLE
Increase boss pattern interval

### DIFF
--- a/warigari_surviver.html
+++ b/warigari_surviver.html
@@ -1246,12 +1246,14 @@
       function pickBossPattern(b) {
         const patterns = ["jump", "airLaser", "timedLaser"];
         b.attackState = patterns[(Math.random() * patterns.length) | 0];
-        b.attackCooldown = 1000;
+        b.attackCooldown = BOSS_PATTERN_DELAY;
         b.laserCount = 0;
         b.jumpCount = 0;
         b.jumping = false;
         b.returning = false;
       }
+
+      const BOSS_PATTERN_DELAY = 1500;
 
       const BOSS_PRE_EFFECT_TIME = {
         laser: 500,
@@ -1406,7 +1408,7 @@
             } else if (!bossLasers.some((l) => l.owner === b)) {
               if (currentWave === 3) {
                 b.attackState = "jump";
-                b.attackCooldown = 1000;
+                b.attackCooldown = BOSS_PATTERN_DELAY;
                 b.jumpCount = 0;
                 b.returning = false;
               } else if (currentWave === 11) {
@@ -1447,7 +1449,7 @@
                 if (currentWave === 3) {
                   b.attackState = "laser";
                   b.laserCount = 0;
-                  b.attackCooldown = 1000;
+                  b.attackCooldown = BOSS_PATTERN_DELAY;
                   b.jumpCount = 0;
                   b.returning = false;
                 } else if (currentWave === 11) {
@@ -1467,7 +1469,7 @@
               if (currentWave === 7) {
                 b.attackState = "timedLaser";
                 b.laserCount = 0;
-                b.attackCooldown = 1000;
+                b.attackCooldown = BOSS_PATTERN_DELAY;
               } else if (currentWave === 11) {
                 pickBossPattern(b);
               }
@@ -1492,7 +1494,7 @@
               if (currentWave === 7) {
                 b.attackState = "airLaser";
                 b.laserCount = 0;
-                b.attackCooldown = 1000;
+                b.attackCooldown = BOSS_PATTERN_DELAY;
               } else if (currentWave === 11) {
                 pickBossPattern(b);
               }


### PR DESCRIPTION
## Summary
- Add `BOSS_PATTERN_DELAY` constant to control pause between boss attack patterns
- Apply delay when selecting or transitioning boss patterns to slow pattern cadence

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bf9cd7e4b08332b0a60fd5b639622c