### PR TITLE
Extend exp orb lifetime and add disappearance warning

### DIFF
--- a/warigari_surviver.html
+++ b/warigari_surviver.html
@@ -1522,7 +1522,7 @@
           vy: -200 - Math.random() * 200,
           gravity: 400,
           value: expOrbValue,
-          life: 5000, // 5초 후 사라짐
+          life: 6000, // 6초 후 사라짐
         });
       }
 
@@ -2573,6 +2573,9 @@
         // 경험치 구슬
         for (const orb of expOrbs) {
           ctx.save();
+          if (orb.life < 1000) {
+            ctx.globalAlpha = Math.max(orb.life / 1000, 0);
+          }
           ctx.fillStyle = "#4ade80";
           ctx.shadowBlur = 8;
           ctx.shadowColor = "#4ade80";


### PR DESCRIPTION
## Summary
- Increase experience orb lifetime from 5s to 6s
- Fade out orbs during their last second as a warning before they vanish

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bfa86837f083329ec13d6081f14335