### PR TITLE
fix: show acquired upgrades clearly

### DIFF
--- a/warigari_surviver.html
+++ b/warigari_surviver.html
@@ -156,11 +156,15 @@
       position: absolute;
       right: 12px;
       top: 10px;
-      z-index: 2;
+      z-index: 20;
       display: flex;
+      flex-wrap: wrap;
+      justify-content: flex-end;
       gap: 8px;
       font-weight: 700;
       text-shadow: 0 2px 6px #0009;
+      max-width: calc(100% - 24px);
+      pointer-events: none;
     }
 
     .upgrade-hud .upgrade-icon {


### PR DESCRIPTION
## Summary
- keep acquired upgrade icons above level-up overlay
- wrap upgrade HUD to avoid clipping on narrow screens

## Testing
- `npm test` *(fails: npm not installed)*
- `apt-get update` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bfb87ab9dc8332929e23c6b2115687