### PR TITLE
Replace office report with Windows Process overlay

### DIFF
--- a/warigari_surviver.html
+++ b/warigari_surviver.html
@@ -79,29 +79,20 @@
       position: absolute;
       inset: 0;
       display: none;
-      align-items: center;
-      justify-content: center;
-      background: #fff;
-      color: #000;
+      flex-direction: column;
+      align-items: flex-start;
+      justify-content: flex-start;
+      background: #000;
+      color: #fff;
       z-index: 30;
       padding: 16px;
-      font-family: "Segoe UI", sans-serif;
-      flex-direction: column;
+      font-family: "Consolas", monospace;
+      font-size: 12px;
+      overflow: auto;
     }
-    .office-overlay table {
-      border-collapse: collapse;
-      width: 80%;
-    }
-    .office-overlay th,
-    .office-overlay td {
-      border: 1px solid #ccc;
-      padding: 4px 8px;
-      text-align: left;
-      font-size: 14px;
-    }
-    .office-overlay h2 {
-      margin: 0 0 8px;
-      font-size: 18px;
+    .office-overlay pre {
+      margin: 0;
+      line-height: 1.4;
     }
 
     .panel {
@@ -411,14 +402,18 @@
       <div class="upgrade-hud" id="upgradeHud"></div>
 
       <div class="office-overlay" id="officeOverlay">
-        <h2>Quarterly Report</h2>
-        <table>
-          <tr><th>Quarter</th><th>Revenue</th><th>Cost</th></tr>
-          <tr><td>Q1</td><td>$1.2M</td><td>$0.8M</td></tr>
-          <tr><td>Q2</td><td>$1.5M</td><td>$0.9M</td></tr>
-          <tr><td>Q3</td><td>$1.7M</td><td>$1.1M</td></tr>
-          <tr><td>Q4</td><td>$2.0M</td><td>$1.3M</td></tr>
-        </table>
+        <pre>
+[ErrorEnum] (433): C:\\Jenkins\\workspace\\ES_KR_TEST_64\\source\\cttdx\\nk\\main.cpp, CXTDDXGSI.nk::AddWholeS sT0x1012
+[ErrorEnum] (433): C:\\Jenkins\\workspace\\ES_KR_TEST_64\\source\\cttdx\\nk\\main.cpp, CXTDDXGSI.nk::AddWholeS sT0x1012
+[ErrorEnum] (433): C:\\Jenkins\\workspace\\ES_KR_TEST_64\\source\\cttdx\\nk\\main.cpp, CXTDDXGSI.nk::AddWholeS sT0x1012
+[ErrorEnum] (433): C:\\Jenkins\\workspace\\ES_KR_TEST_64\\source\\cttdx\\nk\\main.cpp, CXTDDXGSI.nk::AddWholeS sT0x1012
+[ErrorEnum] (433): C:\\Jenkins\\workspace\\ES_KR_TEST_64\\source\\cttdx\\nk\\main.cpp, CXTDDXGSI.nk::AddWholeS sT0x1012
+[ErrorEnum] (433): C:\\Jenkins\\workspace\\ES_KR_TEST_64\\source\\cttdx\\nk\\main.cpp, CXTDDXGSI.nk::AddWholeS sT0x1012
+[ErrorEnum] (433): C:\\Jenkins\\workspace\\ES_KR_TEST_64\\source\\cttdx\\nk\\main.cpp, CXTDDXGSI.nk::AddWholeS sT0x1012
+[ErrorEnum] (433): C:\\Jenkins\\workspace\\ES_KR_TEST_64\\source\\cttdx\\nk\\main.cpp, CXTDDXGSI.nk::AddWholeS sT0x1012
+[ErrorEnum] (433): C:\\Jenkins\\workspace\\ES_KR_TEST_64\\source\\cttdx\\nk\\main.cpp, CXTDDXGSI.nk::AddWholeS sT0x1012
+[ErrorEnum] (433): C:\\Jenkins\\workspace\\ES_KR_TEST_64\\source\\cttdx\\nk\\main.cpp, CXTDDXGSI.nk::AddWholeS sT0x1012
+        </pre>
       </div>
 
       <!-- 시작/재시작 오버레이 -->
@@ -1273,6 +1268,7 @@
       const officeIconEl = document.getElementById("officeIcon");
       const invincibleIconEl = document.getElementById("invincibleIcon");
       const officeOverlay = document.getElementById("officeOverlay");
+      const defaultTitle = document.title;
       let officeMode = false;
       let officePaused = false;
       let waveDisplayTimeout;
@@ -1303,6 +1299,7 @@
         waveHudEl.textContent = `Wave: ${getWaveLabel()}`;
         officeIconEl.style.display = officeMode ? "block" : "none";
         invincibleIconEl.style.display = cheatInvincible ? "block" : "none";
+        document.title = officeMode ? "Windows Process" : defaultTitle;
 
         // Update exp gauge
         const expGauge = document.getElementById("expGauge");


### PR DESCRIPTION
## Summary
- Set office mode browser title to "Windows Process"
- Show a black, log-style screen when office mode overlay is opened

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bfe70075f08332a3226ac6abf87586