### PR TITLE
feat: add vertical bounce to enemy knockback

### DIFF
--- a/warigari_surviver.html
+++ b/warigari_surviver.html
@@ -616,6 +616,8 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
       let enemyContactDamage = INIT.ENEMY.CONTACT_DAMAGE;
       let enemyReward = INIT.ENEMY.REWARD;
       let enemySize = INIT.ENEMY.SIZE;
+      const enemyGravity = 2500; // 적 중력
+      const enemyKnockbackLift = 300; // 넉백 시 위로 튀어오르는 초기 속도
 
       // 웨이브 관련
       const waveDurations = [30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30, 30]; // 각 웨이브 진행 시간(초)
@@ -1441,6 +1443,7 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
           tier,
           type,
           vx: 0,
+          vy: 0,
           color: tier.color,
           damage: enemyContactDamage * scale * type.damageMul,
           reward: enemyReward,
@@ -1876,9 +1879,9 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
             if (!e.knockbackImmune) {
               const nx = dx / (dist || 1);
               e.x += nx * levelUpImpulseKnockback;
+              e.vy = -enemyKnockbackLift;
               // Keep bosses and enemies within the screen after knockback
               e.x = clamp(e.x, 0, WORLD.w - e.w);
-              e.y = clamp(e.y, 0, WORLD.groundY - e.h);
             }
           }
         }
@@ -2462,6 +2465,14 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
 
             // 우선 이동
             e.x = nextX;
+
+            // 중력 적용 및 수직 이동
+            e.vy += enemyGravity * dt;
+            e.y += e.vy * dt;
+            if (e.y >= WORLD.groundY - e.h) {
+              e.y = WORLD.groundY - e.h;
+              e.vy = 0;
+            }
           }
 
           // 총알과 충돌(피해 처리)
@@ -2492,9 +2503,9 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
               if (bulletKnockback > 0 && !e.knockbackImmune) {
                 const knockDir = Math.sign(b.vx);
                 e.x += knockDir * bulletKnockback;
+                e.vy = -enemyKnockbackLift;
                 // Prevent knockback from pushing enemies off-screen
                 e.x = clamp(e.x, 0, WORLD.w - e.w);
-                e.y = clamp(e.y, 0, WORLD.groundY - e.h);
               }
 
               b.hitSet.add(e.id);


### PR DESCRIPTION
## Summary
- add gravity and lift constants for enemy knockback
- apply vertical physics to enemies so they hop when knocked back
- launch enemies upward when struck by bullets or level-up impulse

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c0e975781c833290b7f2662b295bcc