### PR TITLE
fix: prevent rapid direction changes when holding spacebar

### DIFF
--- a/warigari_surviver.html
+++ b/warigari_surviver.html
@@ -1093,6 +1093,7 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
               startHold();
             }
           } else if (!spaceLocked) {
+            spaceLocked = true;
             if (!running) {
               startGame();
             } else if (!paused) {


### PR DESCRIPTION
## Summary
- prevent repeated direction flipping by locking spacebar input until key release

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c1281ac5c4833290253d45af6d2ba8