### PR TITLE
Align sword range with visual blade length and widen swing

### DIFF
--- a/warigari_surviver.html
+++ b/warigari_surviver.html
@@ -1919,6 +1919,7 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
           life: 0,
           duration: 150, // swing time
           hold: 50,
+          holdLife: 0,
           range: swordRange,
         });
         for (let i = enemies.length - 1; i >= 0; i--) {
@@ -2277,8 +2278,13 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
         // 검 휘두름 이펙트 업데이트
         for (let i = swordSwings.length - 1; i >= 0; i--) {
           const s = swordSwings[i];
-          s.life += dt * 1000;
-          if (s.life >= s.duration + s.hold) swordSwings.splice(i, 1);
+          if (s.life < s.duration) {
+            s.life += dt * 1000;
+            if (s.life > s.duration) s.life = s.duration;
+          } else {
+            s.holdLife += dt * 1000;
+            if (s.holdLife >= s.hold) swordSwings.splice(i, 1);
+          }
         }
 
         // 궤도 구슬 회전
@@ -3094,7 +3100,7 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
         // 검 휘두름 이펙트 및 검 그리기
         ctx.save();
         for (const s of swordSwings) {
-          const progress = Math.min(s.life / s.duration, 1);
+          const progress = s.life / s.duration;
           const handleLen = 20;
           const bladeLen = s.range - handleLen * 2;
           ctx.save();

--- a/warigari_surviver.html
+++ b/warigari_surviver.html
@@ -1917,7 +1917,8 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
           y: py,
           dir: player.dir,
           life: 0,
-          duration: 150,
+          duration: 150, // swing time
+          hold: 50,
           range: swordRange,
         });
         for (let i = enemies.length - 1; i >= 0; i--) {
@@ -2277,7 +2278,7 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
         for (let i = swordSwings.length - 1; i >= 0; i--) {
           const s = swordSwings[i];
           s.life += dt * 1000;
-          if (s.life >= s.duration) swordSwings.splice(i, 1);
+          if (s.life >= s.duration + s.hold) swordSwings.splice(i, 1);
         }
 
         // 궤도 구슬 회전
@@ -2972,13 +2973,13 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
           ctx.translate(cx, cy);
           ctx.scale(player.dir, 1);
           ctx.rotate(-11 * Math.PI / 18);
-          ctx.shadowColor = `rgba(255, 255, 0, ${0.5 * glow})`;
+          ctx.shadowColor = `rgba(147, 197, 253, ${0.5 * glow})`;
           ctx.shadowBlur = 10 * glow;
           ctx.fillStyle = "#b45309";
           ctx.fillRect(0, -3, handleLen, 6);
           ctx.fillStyle = "#d1d5db";
           ctx.fillRect(handleLen - 2, -8, 4, 16);
-          ctx.fillStyle = `hsl(50, 100%, ${85 + 10 * glow}%)`;
+          ctx.fillStyle = `hsl(210, 100%, ${65 + 10 * glow}%)`;
           ctx.fillRect(handleLen, -4, bladeLen, 8);
           ctx.restore();
         }
@@ -3092,7 +3093,7 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
         // 검 휘두름 이펙트 및 검 그리기
         ctx.save();
         for (const s of swordSwings) {
-          const progress = s.life / s.duration;
+          const progress = Math.min(s.life / s.duration, 1);
           const handleLen = 20;
           const bladeLen = s.range - handleLen * 2;
           ctx.save();
@@ -3103,7 +3104,7 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
           ctx.fillRect(0, -3, handleLen, 6);
           ctx.fillStyle = "#d1d5db";
           ctx.fillRect(handleLen - 2, -8, 4, 16);
-          ctx.fillStyle = "#e5e7eb";
+          ctx.fillStyle = "#93c5fd";
           ctx.fillRect(handleLen, -4, bladeLen, 8);
           ctx.restore();
         }

--- a/warigari_surviver.html
+++ b/warigari_surviver.html
@@ -1911,6 +1911,7 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
       function swingSword() {
         const px = player.x + player.w / 2;
         const py = player.y + player.h / 2;
+        const handleLen = 20;
         swordSwings.push({
           x: px,
           y: py,
@@ -1925,10 +1926,10 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
           const ey = e.y + e.h / 2;
           const dx = ex - px;
           const dy = ey - py;
-          const dist = Math.hypot(dx, dy);
-          if (dist <= swordRange) {
+          const dist = Math.hypot(dx, dy) - Math.max(e.w, e.h) / 2;
+          if (dist <= swordRange - handleLen) {
             const ang = Math.atan2(dy, dx * player.dir);
-            if (ang >= -Math.PI / 2 && ang <= Math.PI / 6) {
+            if (ang >= -11 * Math.PI / 18 && ang <= Math.PI / 6) {
               const raw = swordDamage - (e.defense || 0);
               const dmg = Math.min(Math.max(raw, 0), e.hp);
               e.hp -= dmg;
@@ -2965,7 +2966,7 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
           const cx = player.x + player.w / 2;
           const cy = player.y + player.h / 2;
           const raiseProgress = Math.min(swordTimer / swordCooldown, 1);
-          const angle = Math.PI / 6 - (2 * Math.PI / 3) * raiseProgress;
+          const angle = Math.PI / 6 - (7 * Math.PI / 9) * raiseProgress;
           const handleLen = 20;
           const bladeLen = swordRange - handleLen;
           ctx.save();
@@ -3096,7 +3097,7 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
           ctx.save();
           ctx.translate(s.x, s.y);
           ctx.scale(s.dir, 1);
-          ctx.rotate(-Math.PI / 2 + (2 * Math.PI / 3) * progress);
+          ctx.rotate(-11 * Math.PI / 18 + (7 * Math.PI / 9) * progress);
           ctx.fillStyle = "#b45309";
           ctx.fillRect(0, -3, handleLen, 6);
           ctx.fillStyle = "#d1d5db";

--- a/warigari_surviver.html
+++ b/warigari_surviver.html
@@ -2968,18 +2968,19 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
           const cy = player.y + player.h / 2;
           const handleLen = 20;
           const bladeLen = swordRange - handleLen * 2;
-          const glow = Math.min(swordTimer / swordCooldown, 1);
+          const glowProgress = Math.min(swordTimer / swordCooldown, 1);
+          const glow = glowProgress * glowProgress;
           ctx.save();
           ctx.translate(cx, cy);
           ctx.scale(player.dir, 1);
           ctx.rotate(-11 * Math.PI / 18);
-          ctx.shadowColor = `rgba(147, 197, 253, ${0.5 * glow})`;
-          ctx.shadowBlur = 10 * glow;
+          ctx.shadowColor = `rgba(147, 197, 253, ${0.7 * glow})`;
+          ctx.shadowBlur = 20 * glow;
           ctx.fillStyle = "#b45309";
           ctx.fillRect(0, -3, handleLen, 6);
           ctx.fillStyle = "#d1d5db";
           ctx.fillRect(handleLen - 2, -8, 4, 16);
-          ctx.fillStyle = `hsl(210, 100%, ${65 + 10 * glow}%)`;
+          ctx.fillStyle = `hsl(210, 100%, ${55 + 35 * glow}%)`;
           ctx.fillRect(handleLen, -4, bladeLen, 8);
           ctx.restore();
         }

--- a/warigari_surviver.html
+++ b/warigari_surviver.html
@@ -2965,19 +2965,20 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
         if (swordEnabled && swordSwings.length === 0) {
           const cx = player.x + player.w / 2;
           const cy = player.y + player.h / 2;
-          const raiseProgress = Math.min(swordTimer / swordCooldown, 1);
-          const angle = Math.PI / 6 - (7 * Math.PI / 9) * raiseProgress;
           const handleLen = 20;
           const bladeLen = swordRange - handleLen * 2;
+          const glow = Math.min(swordTimer / swordCooldown, 1);
           ctx.save();
           ctx.translate(cx, cy);
           ctx.scale(player.dir, 1);
-          ctx.rotate(angle);
+          ctx.rotate(-11 * Math.PI / 18);
+          ctx.shadowColor = `rgba(255, 255, 0, ${0.5 * glow})`;
+          ctx.shadowBlur = 10 * glow;
           ctx.fillStyle = "#b45309";
           ctx.fillRect(0, -3, handleLen, 6);
           ctx.fillStyle = "#d1d5db";
           ctx.fillRect(handleLen - 2, -8, 4, 16);
-          ctx.fillStyle = "#e5e7eb";
+          ctx.fillStyle = `hsl(50, 100%, ${85 + 10 * glow}%)`;
           ctx.fillRect(handleLen, -4, bladeLen, 8);
           ctx.restore();
         }

--- a/warigari_surviver.html
+++ b/warigari_surviver.html
@@ -2968,7 +2968,7 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
           const raiseProgress = Math.min(swordTimer / swordCooldown, 1);
           const angle = Math.PI / 6 - (7 * Math.PI / 9) * raiseProgress;
           const handleLen = 20;
-          const bladeLen = swordRange - handleLen;
+          const bladeLen = swordRange - handleLen * 2;
           ctx.save();
           ctx.translate(cx, cy);
           ctx.scale(player.dir, 1);
@@ -3093,7 +3093,7 @@ Press CTRL+C to abort or wait for forced reboot in 30 seconds.
         for (const s of swordSwings) {
           const progress = s.life / s.duration;
           const handleLen = 20;
-          const bladeLen = s.range - handleLen;
+          const bladeLen = s.range - handleLen * 2;
           ctx.save();
           ctx.translate(s.x, s.y);
           ctx.scale(s.dir, 1);


### PR DESCRIPTION
## Summary
- Match sword hit distance to blade length for more intuitive melee combat
- Extend idle sword raise and swing arc to ~110° for a fuller overhead motion

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c175934e48833290eb415e38750e85